### PR TITLE
Stop crash with Advanced Fluid Cover

### DIFF
--- a/src/main/java/com/impact/mods/gregtech/tileentities/covers/GTC_AdvFluidDetector.java
+++ b/src/main/java/com/impact/mods/gregtech/tileentities/covers/GTC_AdvFluidDetector.java
@@ -5,6 +5,7 @@ import gregtech.api.gui.GT_GUICover;
 import gregtech.api.gui.widgets.GT_GuiIntegerTextBox;
 import gregtech.api.interfaces.tileentity.ICoverable;
 import gregtech.api.net.GT_Packet_TileEntityCover;
+import gregtech.api.objects.GT_ItemStack;
 import gregtech.api.util.GT_CoverBehavior;
 import gregtech.api.util.GT_Utility;
 import net.minecraft.entity.player.EntityPlayer;
@@ -51,7 +52,14 @@ public class GTC_AdvFluidDetector extends GT_CoverBehavior {
 		}
 		return aCoverVariable;
 	}
-	
+
+	public boolean isCoverPlaceable(byte aSide, GT_ItemStack aStack, ICoverable aTileEntity) {
+		if(!(aTileEntity instanceof IFluidHandler)) {
+			return false;
+		}
+		return true;
+	}
+
 	public int onCoverScrewdriverclick(byte aSide, int aCoverID, int aCoverVariable, ICoverable aTileEntity, EntityPlayer aPlayer, float aX, float aY, float aZ) {
 		return aCoverVariable;
 	}

--- a/src/main/java/com/impact/mods/gregtech/tileentities/multi/storage/GTMTE_MultiTank.java
+++ b/src/main/java/com/impact/mods/gregtech/tileentities/multi/storage/GTMTE_MultiTank.java
@@ -44,15 +44,15 @@ import static space.impact.api.multiblocks.alignment.constructable.IMultiBlockIn
 import static space.impact.api.multiblocks.structure.StructureUtility.ofBlock;
 import static space.impact.api.multiblocks.structure.StructureUtility.ofBlockAnyMeta;
 
-public class GTMTE_MultiTank extends GT_MetaTileEntity_MultiBlockBase implements IFluidHandler {
+public class GTMTE_MultiTank extends GT_MetaTileEntity_MultiBlockBase {
 	
+	public final int MAX_DISTINCT_FLUIDS = 25;
 	private final HashSet<GTMTE_TankHatch> sMultiHatches = new HashSet<>();
 	private final Block glassIC2 = IGlassBlock;
 	private final Block CASING = sBlockCasings8;
 	private final Block CASING_TANK = FluidTankBlock;
 	private final byte fluidSelector = 0;
-	private final int MAX_DISTINCT_FLUIDS = 25;
-	public MultiFluidHandler mfh;
+	private MultiFluidHandler mfh;
 	int CASING_TEXTURE_ID = 176;
 	private int runningCost = 0;
 	private boolean doVoidExcess = false;
@@ -508,8 +508,7 @@ public class GTMTE_MultiTank extends GT_MetaTileEntity_MultiBlockBase implements
 		
 	}
 	
-	@Override
-	public FluidTankInfo[] getTankInfo(ForgeDirection from) {
+	public FluidTankInfo[] getMultiTankInfo() {
 		if (mfh == null) {
 			return null;
 		}

--- a/src/main/java/com/impact/mods/gregtech/tileentities/multi/storage/GTMTE_SingleTank.java
+++ b/src/main/java/com/impact/mods/gregtech/tileentities/multi/storage/GTMTE_SingleTank.java
@@ -43,15 +43,15 @@ import static space.impact.api.multiblocks.alignment.constructable.IMultiBlockIn
 import static space.impact.api.multiblocks.structure.StructureUtility.ofBlock;
 import static space.impact.api.multiblocks.structure.StructureUtility.ofBlockAnyMeta;
 
-public class GTMTE_SingleTank extends GT_MetaTileEntity_MultiBlockBase implements IFluidHandler {
+public class GTMTE_SingleTank extends GT_MetaTileEntity_MultiBlockBase {
 	
+	public final int MAX_DISTINCT_FLUIDS = 1;
 	private final HashSet<GTMTE_TankHatch> sMultiHatches = new HashSet<>();
 	private final Block glassIC2 = IGlassBlock;
 	private final Block CASING = sBlockCasings8;
 	private final Block CASING_TANK = FluidTankBlock;
 	private final byte fluidSelector = 0;
-	private final int MAX_DISTINCT_FLUIDS = 1;
-	public MultiFluidHandler mfh;
+	private MultiFluidHandler mfh;
 	int CASING_TEXTURE_ID = 176;
 	private int runningCost = 0;
 	private boolean doVoidExcess = false;
@@ -464,8 +464,7 @@ public class GTMTE_SingleTank extends GT_MetaTileEntity_MultiBlockBase implement
 		});
 	}
 	
-	@Override
-	public FluidTankInfo[] getTankInfo(ForgeDirection from) {
+	public FluidTankInfo[] getMultiTankInfo() {
 		if (mfh == null) {
 			return null;
 		}

--- a/src/main/java/com/impact/mods/waila/ImpactPlugin.java
+++ b/src/main/java/com/impact/mods/waila/ImpactPlugin.java
@@ -23,6 +23,8 @@ import com.impact.mods.gregtech.tileentities.multi.parallelsystem.GTMTE_Parallel
 import com.impact.mods.gregtech.tileentities.multi.parallelsystem.GTMTE_SpaceSatellite_Receiver;
 import com.impact.mods.gregtech.tileentities.multi.parallelsystem.GTMTE_TowerCommunication;
 import com.impact.mods.gregtech.tileentities.multi.storage.GTMTE_LapPowerStation;
+import com.impact.mods.gregtech.tileentities.multi.storage.GTMTE_MultiTank;
+import com.impact.mods.gregtech.tileentities.multi.storage.GTMTE_SingleTank;
 import com.impact.mods.gregtech.tileentities.multi.units.GTMTE_Aerostat;
 import gregtech.api.enums.Dyes;
 import gregtech.api.interfaces.metatileentity.IMetaTileEntity;
@@ -46,6 +48,9 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
 import net.minecraftforge.common.util.ForgeDirection;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTankInfo;
+import net.minecraftforge.fluids.IFluidHandler;
 import tterrag.wailaplugins.api.Plugin;
 import tterrag.wailaplugins.plugins.PluginBase;
 
@@ -111,6 +116,8 @@ public class ImpactPlugin extends PluginBase {
         final GTMTE_Mining_Coal coal_miner = tMeta instanceof GTMTE_Mining_Coal ? ((GTMTE_Mining_Coal) tMeta) : null;
         final GTMTE_BasicMiner basic_miner = tMeta instanceof GTMTE_BasicMiner ? ((GTMTE_BasicMiner) tMeta) : null;
         final GTMTE_AdvancedMiner adv_miner = tMeta instanceof GTMTE_AdvancedMiner ? ((GTMTE_AdvancedMiner) tMeta) : null;
+        final GTMTE_SingleTank single_tank = tMeta instanceof GTMTE_SingleTank ? ((GTMTE_SingleTank) tMeta) : null;
+        final GTMTE_MultiTank multi_tank = tMeta instanceof GTMTE_MultiTank ? ((GTMTE_MultiTank) tMeta) : null;
     
         final boolean showTransformer = tMeta instanceof GT_MetaTileEntity_Transformer && getConfig("transformer");
         final boolean showSolar = tMeta instanceof GT_MetaTileEntity_Boiler_Solar && getConfig("solar");
@@ -293,7 +300,24 @@ public class ImpactPlugin extends PluginBase {
                 if (tag.getBoolean("wMox")) currenttip.add(color[3] + trans("waila.reactor.mox"));
                 if (tag.getBoolean("wFastDecay")) currenttip.add(color[2] + trans("waila.reactor.fastdecay"));
             }
-    
+
+            if (single_tank != null || multi_tank != null) {
+                int maxFluids = multi_tank != null ? multi_tank.MAX_DISTINCT_FLUIDS : single_tank.MAX_DISTINCT_FLUIDS;
+                int capacity = tag.getInteger("capacityPerFluid");
+                final NBTTagCompound fluidsTag = (NBTTagCompound) tag.getTag("fluids");
+                for (int i = 0; i < maxFluids; i++) {
+                    final NBTTagCompound fnbt = (NBTTagCompound) fluidsTag.getTag("" + i);
+                    if (fnbt == null) {
+                        continue;
+                    }
+                    FluidStack fs = FluidStack.loadFluidStackFromNBT(fnbt);
+                    currenttip.add(
+                            NumberFormat.getNumberInstance().format(fs.amount) + "L /" +
+						    NumberFormat.getNumberInstance().format(capacity) + "L: " +
+                            fs.getLocalizedName());
+                }
+            }
+   
             String facingStr = "Facing";
             if (showTransformer && tag.hasKey("isAllowedToWork")) {
                 currenttip.add(


### PR DESCRIPTION
Reject cover if not IFluidHandler
Avoid the crash on the multi-block tanks, doesn't fix cover behavior though.